### PR TITLE
Fixed a bug with plates disappearing

### DIFF
--- a/Assets/Scripts/CounterScripts/ClearCounterScripts/ClearCounter.cs
+++ b/Assets/Scripts/CounterScripts/ClearCounterScripts/ClearCounter.cs
@@ -45,7 +45,7 @@ public class ClearCounter : BaseCounter
                     {
                         if (plate.TryAddIngridient(player.KitchenObject.KitchenObjectSO))
                         {
-                            this.KitchenObject.DestroySelf();
+                            player.KitchenObject.DestroySelf();
                         }
                     }
                 }


### PR DESCRIPTION
Fixed a bug when you put a KitchenObject onto a plate which is on a ClearCounter, the plate is destroyed